### PR TITLE
Change empty cart page to show an alert message instead of empty table

### DIFF
--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -3,7 +3,7 @@
   <header class="page-header">
     <h1>My Cart</h1>
   </header>
-
+    <% if enhanced_cart.length > 0 %>
   <div class="panel panel-default items">
     <table class="table table-bordered">
       <thead>
@@ -31,22 +31,30 @@
       </tfoot>
     </table>
   </div>
-
+  
   <div class="row">
-    <div class="col-xs-12">
-      <%= form_tag orders_path do %>
-        <script
-          src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-          data-key="<%= Rails.configuration.stripe[:publishable_key] %>"
-          data-amount="<%= cart_subtotal_cents %>"
-          data-name="Jungle"
-          data-description="Khurram Virani's Jungle Order"
-          data-locale="auto"
-          data-email="kvirani@gmail.com"
-          data-currency="cad">
-        </script>
-      <% end %>
-    </div>
+  <div class="col-xs-12">
+    <%= form_tag orders_path do %>
+    <script
+      src="https://checkout.stripe.com/checkout.js" class="stripe-button"
+      data-key="<%= Rails.configuration.stripe[:publishable_key] %>"
+      data-amount="<%= cart_subtotal_cents %>"
+      data-name="Jungle"
+      data-description="Khurram Virani's Jungle Order"
+      data-locale="auto"
+      data-email="kvirani@gmail.com"
+      data-currency="cad">
+    </script>
+    <% end %>
   </div>
+  </div>
+
+    <% else %>
+      <a href="/products" >
+        <div class="alert alert-warning" role="alert" font-size="1rem">
+        There are no items in your cart. Please add something. 
+        </div>
+      </a> 
+    <% end %>
 
 </section>


### PR DESCRIPTION
Updated show template for the cart to conditionally (based on enhanced_cart) show cart items or alert message that the cart is empty. 
