### PR TITLE
Change link to products to a button to Continue Shopping

### DIFF
--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -50,11 +50,10 @@
   </div>
 
     <% else %>
-      <a href="/products" >
         <div class="alert alert-warning" role="alert" font-size="1rem">
         There are no items in your cart. Please add something. 
         </div>
-      </a> 
+        <%= link_to "Continue Shopping", root_path, class: 'btn btn-lg btn-primary' %>
     <% end %>
 
 </section>


### PR DESCRIPTION
Updated empty cart page to have a Continue Shopping button instead of alert being a link to homepage